### PR TITLE
Update templates to work with current Rust

### DIFF
--- a/templates/cron-rust/content/Cargo.toml.tmpl
+++ b/templates/cron-rust/content/Cargo.toml.tmpl
@@ -4,7 +4,7 @@ authors = ["{{authors}}"]
 description = "{{project-description}}"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.78"
 
 [lib]
 crate-type = ["cdylib"]

--- a/templates/cron-rust/content/spin.toml
+++ b/templates/cron-rust/content/spin.toml
@@ -11,8 +11,8 @@ component = "{{project-name | kebab_case}}"
 cron_expression = "{{cron-expression}}"
 
 [component.{{project-name | kebab_case}}]
-source = "target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+source = "target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/cron-rust/metadata/snippets/component.txt
+++ b/templates/cron-rust/metadata/snippets/component.txt
@@ -3,9 +3,9 @@ component = "{{project-name | kebab_case}}"
 cron_expression = "{{cron-expression}}"
 
 [component.{{project-name | kebab_case}}]
-source = "{{ output-path }}/target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+source = "{{ output-path }}/target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 workdir = "{{ output-path }}"
 watch = ["src/**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
No-one uses `wasm32-wasi` any more Grandad
