### PR TITLE
Vendor `openssl`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { target: "x86_64-unknown-linux-gnu", os: "ubuntu-22.04", arch: "amd64", extension: ""}
+          - { target: "x86_64-unknown-linux-gnu", os: "ubuntu-22.04", arch: "amd64", extension: "", extraArg: "--features openssl/vendored" }
           - { target: "aarch64-unknown-linux-gnu", os: "ubuntu-22.04", arch: "aarch64", extension: "", extraArg: "--features openssl/vendored" }
           - { target: "x86_64-apple-darwin", os: "macos-13", arch: "amd64", extension: "" }
           - { target: "aarch64-apple-darwin", os: "macos-14", arch: "aarch64", extension: "" }


### PR DESCRIPTION
I noticed that the Spin build now sets `--features openssl/vendored` on Ubuntu AMD64 builds, because apparently Ubuntu 22 no longer ships libssl1.1 and apparently this causes woe (https://github.com/spinframework/spin/blob/main/.github/workflows/release.yml#L32).  I dunno if it causes the same woe but a user who was trying a canary ran into a libssl issue and well maybe better safe than sorry.  Definitely feel free to close if it's not needed!
